### PR TITLE
Late static factory method

### DIFF
--- a/Finder.php
+++ b/Finder.php
@@ -66,7 +66,7 @@ class Finder implements \IteratorAggregate, \Countable
      */
     public static function create()
     {
-        return new self();
+        return new static();
     }
 
     /**


### PR DESCRIPTION
When using `Symfony\CS\Finder\DefaultFinder::create()`, we lose all `Symfony\CS\Finder\DefaultFinder::__construct()` properties because main `Finder` does not use late static binding.

This commit resolve the issue.
