### PR TITLE
Use file_get_contents instead of SplFileObject::fpassthru()

### DIFF
--- a/SplFileInfo.php
+++ b/SplFileInfo.php
@@ -62,10 +62,6 @@ class SplFileInfo extends \SplFileInfo
      */
     public function getContents()
     {
-        $file = new \SplFileObject($this->getRealpath(), 'rb');
-        ob_start();
-        $file->fpassthru();
-
-        return ob_get_clean();
+        return file_get_contents($this->getRealPath());
     }
 }


### PR DESCRIPTION
Hi there.
For a local operation, I'm parsing some Apache Log Files.
It's a simple code using the **Finder**, the **Symfony\Finder\SplFileInfo::getContents** function & preg_match_all function : [Sample](https://gist.github.com/4232372)

The biggest file size is 500M, and I have around ten files.
Without the PR, I have to set the "memory_limit" value to **1G** to use the above script. And with my PR the "memory_limit" is really near the biggest file, it's working with **memory_limit** set to 550M.

Also,
When the **PHP Fatal error:  Allowed memory size** comes, without the PR, the standard output is spammed by the loaded content.. Which is really annoying.

I'm using PHP 5.3.17 on a MacOS.
