### PR TITLE
Fix SplFileInfo PHPDoc

### DIFF
--- a/Iterator/ExcludeDirectoryFilterIterator.php
+++ b/Iterator/ExcludeDirectoryFilterIterator.php
@@ -11,24 +11,27 @@
 
 namespace Symfony\Component\Finder\Iterator;
 
+use Symfony\Component\Finder\SplFileInfo;
+
 /**
  * ExcludeDirectoryFilterIterator filters out directories.
  *
  * @author Fabien Potencier <fabien@symfony.com>
  *
- * @extends \FilterIterator<string, \SplFileInfo>
- * @implements \RecursiveIterator<string, \SplFileInfo>
+ * @extends \FilterIterator<string, SplFileInfo>
+ * @implements \RecursiveIterator<string, SplFileInfo>
  */
 class ExcludeDirectoryFilterIterator extends \FilterIterator implements \RecursiveIterator
 {
+    /** @var \Iterator<string, SplFileInfo> */
     private \Iterator $iterator;
     private bool $isRecursive;
     private array $excludedDirs = [];
     private ?string $excludedPattern = null;
 
     /**
-     * @param \Iterator $iterator    The Iterator to filter
-     * @param string[]  $directories An array of directories to exclude
+     * @param \Iterator<string, SplFileInfo> $iterator    The Iterator to filter
+     * @param string[]                       $directories An array of directories to exclude
      */
     public function __construct(\Iterator $iterator, array $directories)
     {

--- a/Iterator/FileTypeFilterIterator.php
+++ b/Iterator/FileTypeFilterIterator.php
@@ -26,8 +26,8 @@ class FileTypeFilterIterator extends \FilterIterator
     private int $mode;
 
     /**
-     * @param \Iterator $iterator The Iterator to filter
-     * @param int       $mode     The mode (self::ONLY_FILES or self::ONLY_DIRECTORIES)
+     * @param \Iterator<string, \SplFileInfo> $iterator The Iterator to filter
+     * @param int                             $mode     The mode (self::ONLY_FILES or self::ONLY_DIRECTORIES)
      */
     public function __construct(\Iterator $iterator, int $mode)
     {

--- a/Iterator/FilecontentFilterIterator.php
+++ b/Iterator/FilecontentFilterIterator.php
@@ -11,13 +11,15 @@
 
 namespace Symfony\Component\Finder\Iterator;
 
+use Symfony\Component\Finder\SplFileInfo;
+
 /**
  * FilecontentFilterIterator filters files by their contents using patterns (regexps or strings).
  *
  * @author Fabien Potencier  <fabien@symfony.com>
  * @author Włodzimierz Gajda <gajdaw@gajdaw.pl>
  *
- * @extends MultiplePcreFilterIterator<string, \SplFileInfo>
+ * @extends MultiplePcreFilterIterator<string, SplFileInfo>
  */
 class FilecontentFilterIterator extends MultiplePcreFilterIterator
 {

--- a/Iterator/MultiplePcreFilterIterator.php
+++ b/Iterator/MultiplePcreFilterIterator.php
@@ -27,9 +27,9 @@ abstract class MultiplePcreFilterIterator extends \FilterIterator
     protected $noMatchRegexps = [];
 
     /**
-     * @param \Iterator $iterator        The Iterator to filter
-     * @param string[]  $matchPatterns   An array of patterns that need to match
-     * @param string[]  $noMatchPatterns An array of patterns that need to not match
+     * @param \Iterator<TKey, TValue> $iterator        The Iterator to filter
+     * @param string[]                $matchPatterns   An array of patterns that need to match
+     * @param string[]                $noMatchPatterns An array of patterns that need to not match
      */
     public function __construct(\Iterator $iterator, array $matchPatterns, array $noMatchPatterns)
     {

--- a/Iterator/PathFilterIterator.php
+++ b/Iterator/PathFilterIterator.php
@@ -11,13 +11,15 @@
 
 namespace Symfony\Component\Finder\Iterator;
 
+use Symfony\Component\Finder\SplFileInfo;
+
 /**
  * PathFilterIterator filters files by path patterns (e.g. some/special/dir).
  *
  * @author Fabien Potencier  <fabien@symfony.com>
  * @author Włodzimierz Gajda <gajdaw@gajdaw.pl>
  *
- * @extends MultiplePcreFilterIterator<string, \SplFileInfo>
+ * @extends MultiplePcreFilterIterator<string, SplFileInfo>
  */
 class PathFilterIterator extends MultiplePcreFilterIterator
 {

--- a/Iterator/RecursiveDirectoryIterator.php
+++ b/Iterator/RecursiveDirectoryIterator.php
@@ -18,6 +18,7 @@ use Symfony\Component\Finder\SplFileInfo;
  * Extends the \RecursiveDirectoryIterator to support relative paths.
  *
  * @author Victor Berchet <victor@suumit.com>
+ * @extends \RecursiveDirectoryIterator<string, SplFileInfo>
  */
 class RecursiveDirectoryIterator extends \RecursiveDirectoryIterator
 {

--- a/Iterator/SortableIterator.php
+++ b/Iterator/SortableIterator.php
@@ -28,6 +28,7 @@ class SortableIterator implements \IteratorAggregate
     public const SORT_BY_MODIFIED_TIME = 5;
     public const SORT_BY_NAME_NATURAL = 6;
 
+    /** @var \Traversable<string, \SplFileInfo> $iterator */
     private \Traversable $iterator;
     private \Closure|int $sort;
 

--- a/Iterator/VcsIgnoredFilterIterator.php
+++ b/Iterator/VcsIgnoredFilterIterator.php
@@ -13,6 +13,9 @@ namespace Symfony\Component\Finder\Iterator;
 
 use Symfony\Component\Finder\Gitignore;
 
+/**
+ * @extends \FilterIterator<string, \SplFileInfo>
+ */
 final class VcsIgnoredFilterIterator extends \FilterIterator
 {
     /**
@@ -30,6 +33,9 @@ final class VcsIgnoredFilterIterator extends \FilterIterator
      */
     private $ignoredPathsCache = [];
 
+    /**
+     * @param \Iterator<string, \SplFileInfo> $iterator
+     */
     public function __construct(\Iterator $iterator, string $baseDir)
     {
         $this->baseDir = $this->normalizePath($baseDir);


### PR DESCRIPTION
Some iterators are fine with \SplFileInfo, some require/use the Symfony Finder variant.
I adjusted the PHPDoc to match reality.
Since the project does not seem to include a PHPStan or Psalm setup I couldn't verify the result that way but performed some local tests.

If this gets approval, I'd also like to get this fixed on the 5.4 branch which we're using.